### PR TITLE
fix no previous prototype warning/error

### DIFF
--- a/driver/bm1682/bm1682_card.c
+++ b/driver/bm1682/bm1682_card.c
@@ -1,6 +1,7 @@
 #include <linux/delay.h>
 #include "bm_common.h"
 #include "bm1682_reg.h"
+#include "bm1682_card.h"
 
 void bm1682_stop_arm9(struct bm_device_info *bmdi)
 {

--- a/driver/bm1682/bm1682_ddr.c
+++ b/driver/bm1682/bm1682_ddr.c
@@ -67,33 +67,33 @@ static u8 calc_ddr_para_id(u32 freq)
 	return (id - 1);
 }
 
-void bm1682_disable_ddr_interleave(struct bm_device_info *bmdi)
+static void bm1682_disable_ddr_interleave(struct bm_device_info *bmdi)
 {
  	u32 data = top_reg_read(bmdi, 0x1c0);
 	top_reg_write(bmdi, 0x1c0, (data & (~(1<<4))) | 0x2);
 }
 
-void bm1682_enable_ddr_interleave(struct bm_device_info *bmdi)
+static void bm1682_enable_ddr_interleave(struct bm_device_info *bmdi)
 {
 	u32 data = top_reg_read(bmdi, 0x1c0);
 	top_reg_write(bmdi, 0x1c0, (data | (1<<4)) | 0x2);
 }
 
-void disable_local_mem_early_resp(struct bm_device_info *bmdi)
+static void disable_local_mem_early_resp(struct bm_device_info *bmdi)
 {
    //Disable the early write for easier simulation
 	u32 data = top_reg_read(bmdi, 0x8);
 	top_reg_write(bmdi, 0x8, data | (1<<9));
 }
 
-void enable_local_mem_early_resp(struct bm_device_info *bmdi)
+static void enable_local_mem_early_resp(struct bm_device_info *bmdi)
 {
    //enable the early write for perfomance
 	u32 data = top_reg_read(bmdi, 0x8);
 	top_reg_write(bmdi, 0x8, data & (~(1<<9)));
 }
 
-void set_ddr_interleave_size(struct bm_device_info *bmdi, u32 size)
+static void set_ddr_interleave_size(struct bm_device_info *bmdi, u32 size)
 {
   /*
   int i;
@@ -325,7 +325,7 @@ static void ddr4_init(struct bm_device_info *bmdi, u32 ddr_ctl)
 	}
 }
 
-int ddr_init_palladium(struct bm_device_info *bmdi, u32 ddr_freq)
+static int ddr_init_palladium(struct bm_device_info *bmdi, u32 ddr_freq)
 {
 	ddr4_init(bmdi, 0);
 	ddr4_init(bmdi, 1);
@@ -756,7 +756,7 @@ static void calc_freq_div(u32 freq, u32 *ref_div, u32 *fb_div)
 }
 
 //configure ddr freq for each channel after ddr initialization
-void ddr_freq_configure(struct bm_device_info *bmdi, u32 ddr_ctl, u32 freq)
+static void ddr_freq_configure(struct bm_device_info *bmdi, u32 ddr_ctl, u32 freq)
 {
 	u32 ref_div = 0, fb_div = 0;
 	u32 data;
@@ -820,7 +820,7 @@ static void ddr_soft_reset(struct bm_device_info *bmdi)
 	top_reg_write(bmdi, 0x14, (data | 0x00001c00));
 }
 
-int ddr_init(struct bm_device_info *bmdi, u32 freq)
+static int ddr_init(struct bm_device_info *bmdi, u32 freq)
 {
 	int ret;
 	u8 id;

--- a/driver/bm1682/bm1682_gmem.c
+++ b/driver/bm1682/bm1682_gmem.c
@@ -1,6 +1,7 @@
 #include "bm_common.h"
 #include "bm_gmem.h"
 #include "bm1682_reg.h"
+#include "bm1682_gmem.h"
 
 #ifndef SOC_MODE
 int bmdrv_bm1682_parse_reserved_mem_info(struct bm_device_info *bmdi)

--- a/driver/bm1682/bm1682_irq.c
+++ b/driver/bm1682/bm1682_irq.c
@@ -2,6 +2,7 @@
 #include "bm_io.h"
 #include "bm_common.h"
 #include "bm1682_reg.h"
+#include "bm1682_irq.h"
 
 extern void bm1682_smmu_get_irq_status(struct bm_device_info *bmdi, u32 *status);
 

--- a/driver/bm1682/bm1682_smmu.c
+++ b/driver/bm1682/bm1682_smmu.c
@@ -96,6 +96,7 @@
  * Data structure to store user address, Pages, sg table mapping
  */
 int bm1682_disable_iommu(struct iommu_ctrl *ctrl);
+void bm1682_smmu_get_irq_status(struct bm_device_info *bmdi, u32 *status);
 static int bm_bo_create(struct bm_buffer_object **bo, struct iommu_region *iommu)
 {
     struct bm_buffer_object *bbo = NULL;

--- a/driver/bm1684/bm1684_base64.c
+++ b/driver/bm1684/bm1684_base64.c
@@ -1,5 +1,6 @@
 #include <linux/ioctl.h>
 #include "bm_common.h"
+#include "bm1684_base64.h"
 
 static unsigned long int base64_compute_dstlen(uint64_t len, bool enc)
 {

--- a/driver/bm1684/bm1684_card.c
+++ b/driver/bm1684/bm1684_card.c
@@ -150,7 +150,7 @@ static void bm1684_init_i2c_for_mcu(struct bm_device_info *bmdi)
 	bmdrv_i2c_init(bmdi, i2c_index, rx_level, tx_level, target_addr);
 }
 
-int bm1684_correct_hw_version(struct bm_device_info *bmdi, u8 hw_version)
+static int bm1684_correct_hw_version(struct bm_device_info *bmdi, u8 hw_version)
 {
 	static u8 chip0_hw_version = 0;
 
@@ -479,7 +479,7 @@ void bm1684_get_fusing_temperature(struct bm_device_info *bmdi, int *max_tmp, in
 #endif
 
 #ifndef SOC_MODE
-void bm1684_stop_smbus(struct bm_device_info *bmdi)
+static void bm1684_stop_smbus(struct bm_device_info *bmdi)
 {
 /* mask i2c2*/
 	int value = 0x0;

--- a/driver/bm1684/bm1684_ce.c
+++ b/driver/bm1684/bm1684_ce.c
@@ -692,12 +692,12 @@ int ce_dmacpy(void *dev, void *dst, void *src, unsigned long len)
 	return 0;
 }
 
-void spacc_clear_int(struct bm_device_info *bmdi)
+static void spacc_clear_int(struct bm_device_info *bmdi)
 {
 	ce_int_clear(bmdi->cinfo.bar_info.io_bar_vaddr.spacc_bar_vaddr);
 }
 
-void spacc_irq_handler(struct bm_device_info *bmdi)
+static void spacc_irq_handler(struct bm_device_info *bmdi)
 {
 	bmdi->spaccdrvctx.got_event_spacc = 1;
 	wake_up(&bmdi->spaccdrvctx.wq_spacc);
@@ -731,7 +731,7 @@ void bm_spacc_free_irq(struct bm_device_info *bmdi)
 	bmdrv_submodule_free_irq(bmdi, SPACC_IRQ_ID);
 }
 
-int spacc_handle_setup(struct bm_device_info *bmdi, struct spacc_batch *batch)
+static int spacc_handle_setup(struct bm_device_info *bmdi, struct spacc_batch *batch)
 {
 	int ret = 0;
 	struct cipher_info const *info;

--- a/driver/bm1684/bm1684_clkrst.c
+++ b/driver/bm1684/bm1684_clkrst.c
@@ -482,7 +482,7 @@ void bmdrv_sw_reset_cdma(struct bm_device_info *bmdi)
 	top_reg_write(bmdi, TOP_SW_RESET1, val);
 }
 
-void bmdrv_clk_set_module_reset(struct bm_device_info* bmdi, BM_MODULE_ID module)
+static void bmdrv_clk_set_module_reset(struct bm_device_info* bmdi, BM_MODULE_ID module)
 {
 	switch (module) {
 	case BM_MODULE_CDMA:

--- a/driver/bm1684/bm1684_ddr.c
+++ b/driver/bm1684/bm1684_ddr.c
@@ -77,7 +77,7 @@ void bm1684_ddr0b_ecc_irq_handler(struct bm_device_info *bmdi)
 	ddr_reg_write_enh(bmdi, 0x1, 0x7c, (status | 0x1f));
 }
 
-void bm1684_ddr1_ecc_irq_handler(struct bm_device_info *bmdi)
+static void bm1684_ddr1_ecc_irq_handler(struct bm_device_info *bmdi)
 {
 	u32 status = ddr_reg_read_enh(bmdi, 0x2, 0x78);
 
@@ -87,7 +87,7 @@ void bm1684_ddr1_ecc_irq_handler(struct bm_device_info *bmdi)
 	ddr_reg_write_enh(bmdi, 0x2, 0x7c, (status | 0x1f));
 }
 
-void bm1684_ddr2_ecc_irq_handler(struct bm_device_info *bmdi)
+static void bm1684_ddr2_ecc_irq_handler(struct bm_device_info *bmdi)
 {
 	u32 status = ddr_reg_read_enh(bmdi, 0x3, 0x78);
 

--- a/driver/bm1684/bm1684_gmem.c
+++ b/driver/bm1684/bm1684_gmem.c
@@ -3,6 +3,7 @@
 #include "bm_pcie.h"
 #include "bm1684_reg.h"
 #include "bm_gmem.h"
+#include "bm1684_gmem.h"
 
 #ifndef SOC_MODE
 int bmdrv_bm1684_parse_reserved_mem_info(struct bm_device_info *bmdi)

--- a/driver/bm1684/bm1684_irq.c
+++ b/driver/bm1684/bm1684_irq.c
@@ -19,7 +19,7 @@ void bm1684_pcie_msi_irq_disable(struct bm_device_info *bmdi)
 	gp_reg_write_enh(bmdi, GP_REG_MSI_DATA, 0x0);
 }
 
-void bm1684_pcie_remap_msi_init(struct pci_dev *pdev, struct bm_device_info *bmdi)
+static void bm1684_pcie_remap_msi_init(struct pci_dev *pdev, struct bm_device_info *bmdi)
 {
 	void __iomem *pcie_top_base_addr = NULL;
 	void __iomem *pcie_iatu_addr = NULL;

--- a/driver/bm1684/bm1684_lpddr4.c
+++ b/driver/bm1684/bm1684_lpddr4.c
@@ -94,7 +94,7 @@ static void dwc_decode_major_msg(struct bm_device_info *bmdi, int msg)
 	}
 }
 
-void mask_train_result(struct bm_device_info *bmdi, u32 index, u32 phase, u32 result)
+static void mask_train_result(struct bm_device_info *bmdi, u32 index, u32 phase, u32 result)
 {
 	bmdi->cinfo.ddr_failmap &= ~(1UL << ((index << 1) + phase));
 	bmdi->cinfo.ddr_failmap |= ((result & 0x1) << ((index << 1) + phase));
@@ -114,7 +114,7 @@ static void dwc_train_status(struct bm_device_info *bmdi, u32 cfg_base,
 	mask_train_result(bmdi, index, train_2d, pass_or_fail);
 }
 
-void dwc_read_msgblock_msg(struct bm_device_info *bmdi, u32 cfg_base, u32 train_2d)
+static void dwc_read_msgblock_msg(struct bm_device_info *bmdi, u32 cfg_base, u32 train_2d)
 {
 	int mail;
 
@@ -438,7 +438,7 @@ static int ddr_phy_init(struct bm_device_info *bmdi, u32 cfg_base, u32 ddr_index
 	return 0;
 }
 
-void dwc_phy_enter_mission(struct bm_device_info *bmdi)
+static void dwc_phy_enter_mission(struct bm_device_info *bmdi)
 {
 	ddr_phy_enter_mission(bmdi, DDR_CTRL0_A, 0);
 	ddr_phy_enter_mission(bmdi, DDR_CTRL0_B, 1);

--- a/driver/bm1684/bm1684_pcie.c
+++ b/driver/bm1684/bm1684_pcie.c
@@ -7,7 +7,7 @@
 #include "bm_common.h"
 #include "bm_card.h"
 
-int bm1684_get_pcie_func_index(struct bm_device_info *bmdi)
+static int bm1684_get_pcie_func_index(struct bm_device_info *bmdi)
 {
 	void __iomem *atu_base_addr;
 	int mode = 0x0;
@@ -608,7 +608,7 @@ int bm1684_setup_bar_dev_layout(struct bm_device_info *bmdi, BAR_LAYOUT_TYPE typ
 	return -1;
 }
 
-int bmdrv_init_for_mode_chose(struct bm_device_info *bmdi, struct pci_dev *pdev, struct bm_bar_info *bari)
+static int bmdrv_init_for_mode_chose(struct bm_device_info *bmdi, struct pci_dev *pdev, struct bm_bar_info *bari)
 {
 	void __iomem *atu_base_addr;
 	void __iomem *cfg_base_addr;
@@ -731,7 +731,7 @@ int bmdrv_pcie_get_mode(struct bm_device_info *bmdi)
 	return mode;
 }
 
-void bmdrv_pcie_set_function1_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
+static void bmdrv_pcie_set_function1_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
 {
 	void __iomem *atu_base_addr;
 	int value = 0x0;
@@ -847,7 +847,7 @@ void bmdrv_pcie_set_function1_iatu_config(struct pci_dev *pdev, struct bm_device
 
 }
 
-void bmdrv_pcie_set_function2_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
+static void bmdrv_pcie_set_function2_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
 {
 	void __iomem *atu_base_addr;
 	int function_num = 0x0;
@@ -939,7 +939,7 @@ void bmdrv_pcie_set_function2_iatu_config(struct pci_dev *pdev, struct bm_device
 
 }
 
-void bmdrv_pcie_set_function3_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
+static void bmdrv_pcie_set_function3_iatu_config(struct pci_dev *pdev, struct bm_device_info *bmdi)
 {
 	void __iomem *atu_base_addr;
 	int function_num = 0x0;
@@ -1031,7 +1031,7 @@ void bmdrv_pcie_set_function3_iatu_config(struct pci_dev *pdev, struct bm_device
 	REG_WRITE32(atu_base_addr, 0x1804, 0x80000000); //address match
 }
 
-int bmdrv_calculate_chip_num(int mode, int function_num)
+static int bmdrv_calculate_chip_num(int mode, int function_num)
 {
 	int chip_seqnum = 0;
 
@@ -1068,7 +1068,7 @@ int bmdrv_calculate_chip_num(int mode, int function_num)
 	return chip_seqnum;
 }
 
-void bmdrv_set_chip_num(int chip_seqnum, struct bm_device_info *bmdi)
+static void bmdrv_set_chip_num(int chip_seqnum, struct bm_device_info *bmdi)
 {
 	void __iomem *abp_addr;
 	int temp_value = 0x0;
@@ -1080,7 +1080,7 @@ void bmdrv_set_chip_num(int chip_seqnum, struct bm_device_info *bmdi)
 	REG_WRITE32(abp_addr, 0, temp_value);
 }
 
-void bmdrv_pcie_perst(struct bm_device_info *bmdi)
+static void bmdrv_pcie_perst(struct bm_device_info *bmdi)
 {
 	int value = 0;
 
@@ -1095,7 +1095,7 @@ void bmdrv_pcie_perst(struct bm_device_info *bmdi)
 	mdelay(300);
 }
 
-int bmdrv_pcie_polling_rc_perst(struct pci_dev *pdev, struct bm_bar_info *bari)
+static int bmdrv_pcie_polling_rc_perst(struct pci_dev *pdev, struct bm_bar_info *bari)
 {
 	int loop = 200;
 	int ret = 0;
@@ -1119,7 +1119,7 @@ int bmdrv_pcie_polling_rc_perst(struct pci_dev *pdev, struct bm_bar_info *bari)
 	return ret;
 }
 
-int bmdrv_pcie_polling_rc_core_rst(struct pci_dev *pdev, struct bm_bar_info *bari)
+static int bmdrv_pcie_polling_rc_core_rst(struct pci_dev *pdev, struct bm_bar_info *bari)
 {
 	int loop = 200;
 	int ret = 0;
@@ -1141,7 +1141,7 @@ int bmdrv_pcie_polling_rc_core_rst(struct pci_dev *pdev, struct bm_bar_info *bar
 	return ret;
 }
 
-void bmdrv_pcie_set_rc_link_speed_gen_x(struct bm_bar_info *bari, int gen_speed)
+static void bmdrv_pcie_set_rc_link_speed_gen_x(struct bm_bar_info *bari, int gen_speed)
 {
 	int value = 0;
 
@@ -1173,7 +1173,7 @@ void bmdrv_pcie_set_rc_link_speed_gen_x(struct bm_bar_info *bari, int gen_speed)
 	REG_READ32(bari->bar0_vaddr + REG_OFFSET_PCIE_iATU, 0xb14);      //dst addr
 }
 
-void bmdrv_pcie_set_rc_max_payload_setting(struct bm_bar_info *bari)
+static void bmdrv_pcie_set_rc_max_payload_setting(struct bm_bar_info *bari)
 {
 	int value = 0;
 
@@ -1189,12 +1189,12 @@ void bmdrv_pcie_set_rc_max_payload_setting(struct bm_bar_info *bari)
 	REG_READ32(bari->bar0_vaddr + REG_OFFSET_PCIE_iATU, 0xb14);      //dst addr
 }
 
-void bmdrv_pcie_enable_rc(struct bm_bar_info *bari)
+static void bmdrv_pcie_enable_rc(struct bm_bar_info *bari)
 {
 	REG_WRITE32(bari->bar0_vaddr + REG_OFFSET_PCIE_APB, 0x258,  REG_READ32(bari->bar0_vaddr + REG_OFFSET_PCIE_APB, 0x258) | 0x1); //enable rc LTSSM
 }
 
-int bmdrv_pcie_polling_rc_link_state(struct bm_bar_info *bari)
+static int bmdrv_pcie_polling_rc_link_state(struct bm_bar_info *bari)
 {
 	int value = 0x0;
 	int count = 0x20;
@@ -1222,7 +1222,7 @@ int bmdrv_pcie_polling_rc_link_state(struct bm_bar_info *bari)
 	return ret;
 }
 
-int try_to_link_as_gen1_speed(struct pci_dev *pdev, struct bm_device_info *bmdi, struct bm_bar_info *bari)
+static int try_to_link_as_gen1_speed(struct pci_dev *pdev, struct bm_device_info *bmdi, struct bm_bar_info *bari)
 {
 	int ret = 0;
 
@@ -1240,7 +1240,7 @@ int try_to_link_as_gen1_speed(struct pci_dev *pdev, struct bm_device_info *bmdi,
 	return ret;
 }
 
-int bmdrv_pcie_rc_init(struct pci_dev *pdev, struct bm_device_info *bmdi, struct bm_bar_info *bari)
+static int bmdrv_pcie_rc_init(struct pci_dev *pdev, struct bm_device_info *bmdi, struct bm_bar_info *bari)
 {
 	int count = 0x5;
 	int ret = 0;
@@ -1342,12 +1342,12 @@ int config_iatu_for_function_x(struct pci_dev *pdev, struct bm_device_info *bmdi
 	return ret;
 }
 
-u32 bmdrv_read_config(struct bm_device_info *bmdi, int cfg_base_addr, int offset)
+static u32 bmdrv_read_config(struct bm_device_info *bmdi, int cfg_base_addr, int offset)
 {
 	return bm_read32(bmdi, cfg_base_addr + offset);
 }
 
-void bmdrv_write_config(struct bm_device_info *bmdi, int cfg_base_addr, int offset, u32 value, u32 mask)
+static void bmdrv_write_config(struct bm_device_info *bmdi, int cfg_base_addr, int offset, u32 value, u32 mask)
 {
 	u32 val = 0;
 	val = bmdrv_read_config(bmdi, cfg_base_addr, offset);
@@ -1355,16 +1355,16 @@ void bmdrv_write_config(struct bm_device_info *bmdi, int cfg_base_addr, int offs
 	bm_write32(bmdi, cfg_base_addr + offset, val);
 }
 
-void bmdrv_pci_busmaster_memory_enable(struct bm_device_info *bmdi, int cfg_base_addr, int offset)
+static void bmdrv_pci_busmaster_memory_enable(struct bm_device_info *bmdi, int cfg_base_addr, int offset)
 {
 	bmdrv_write_config(bmdi, cfg_base_addr, 0x4,0x7,0x7);
 }
 
-void bmdrv_pci_msi_enable(struct bm_device_info *bmdi, int cfg_base_addr)
+static void bmdrv_pci_msi_enable(struct bm_device_info *bmdi, int cfg_base_addr)
 {
 	bmdrv_write_config(bmdi, cfg_base_addr, 0x50,0x1 << 16,0x1<<16);
 }
-void bmdrv_pci_max_payload_setting(struct bm_device_info *bmdi, int cfg_base_addr)
+static void bmdrv_pci_max_payload_setting(struct bm_device_info *bmdi, int cfg_base_addr)
 {
 	bmdrv_write_config(bmdi, cfg_base_addr, 0x78, 0x1 << 5,(0x7 << 5));
 }

--- a/driver/bm1684/bm1684_pld_ddr.c
+++ b/driver/bm1684/bm1684_pld_ddr.c
@@ -12,7 +12,7 @@
 #include "bm_memcpy.h"
 #include "bm1684_ddr.h"
 
-void ddr_phy_init(struct bm_device_info *bmdi, u32 cfg_base)
+static void ddr_phy_init(struct bm_device_info *bmdi, u32 cfg_base)
 {
 	u32 read_data = 0;
 	// phy register, original is APB address which is half word based

--- a/driver/bm1684/bm1684_smbus.c
+++ b/driver/bm1684/bm1684_smbus.c
@@ -2,6 +2,7 @@
 #include "bm_common.h"
 #include "bm1684_reg.h"
 #include "bm1684_card.h"
+#include "bm1684_smbus.h"
 
 void bmdrv_smbus_set_default_value(struct pci_dev *pdev, struct bm_device_info *bmdi)
 {

--- a/driver/bm1684/bm1684_smmu.c
+++ b/driver/bm1684/bm1684_smmu.c
@@ -738,7 +738,7 @@ int bm1684_disable_iommu(struct iommu_ctrl *ctrl)
  * 3. kernel driver write SMMU_ICR
  * 4. device iommu continue work(should be reset in current implementation)
  */
-int bm1684_iommu_irq(struct iommu_ctrl *ctrl)
+static int bm1684_iommu_irq(struct iommu_ctrl *ctrl)
 {
 	struct bm_memcpy_info *memcpy_info = container_of(ctrl, struct bm_memcpy_info, iommuctl);
 	struct bm_device_info *bmdi = container_of(memcpy_info, struct bm_device_info, memcpy_info);

--- a/driver/bm_api.c
+++ b/driver/bm_api.c
@@ -13,7 +13,7 @@
 #include "bm_thread.h"
 
 DEFINE_SPINLOCK(msg_dump_lock);
-void bmdev_dump_reg(struct bm_device_info *bmdi, u32 channel)
+static void bmdev_dump_reg(struct bm_device_info *bmdi, u32 channel)
 {
     int i=0;
     spin_lock(&msg_dump_lock);
@@ -124,7 +124,7 @@ void bmdrv_api_deinit(struct bm_device_info *bmdi, u32 channel)
 #define LIB_MAX_NAME_LEN 64
 #define FUNC_MAX_NAME_LEN 64
 
-int bmdrv_api_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_api)
+static int bmdrv_api_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_api)
 {
 	int ret = 0;
 	struct bmcpu_lib *lib_node;
@@ -194,7 +194,7 @@ int bmdrv_api_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_api)
 	return 0;
 }
 
-int bmdrv_api_unload_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_api)
+static int bmdrv_api_unload_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_api)
 {
 	int ret = 0;
 	int i;
@@ -256,7 +256,7 @@ int bmdrv_api_unload_lib_process(struct bm_device_info *bmdi, bm_api_ext_t bm_ap
 	return 0;
 }
 
-int bmdrv_api_dyn_get_func_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
+static int bmdrv_api_dyn_get_func_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
 {
 	int ret;
 	static int f_id = 22;
@@ -310,7 +310,7 @@ int bmdrv_api_dyn_get_func_process(struct bm_device_info *bmdi, bm_api_ext_t *p_
 	return ret;
 }
 
-int bmdrv_api_dyn_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
+static int bmdrv_api_dyn_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
 {
 	int ret;
 	bm_api_dyn_cpu_load_library_internal_t api_cpu_load_library_internal;
@@ -368,7 +368,7 @@ int bmdrv_api_dyn_load_lib_process(struct bm_device_info *bmdi, bm_api_ext_t *p_
 	return 0;
 }
 
-int bmdrv_api_dyn_unload_lib_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
+static int bmdrv_api_dyn_unload_lib_process(struct bm_device_info *bmdi, bm_api_ext_t *p_bm_api)
 {
 	int ret;
 	bm_api_dyn_cpu_load_library_internal_t api_cpu_load_library_internal;
@@ -537,7 +537,7 @@ int bmdrv_send_api_close(struct bm_device_info *bmdi, struct file *file, u8 *pro
 	return ret;
 }
 
-int ksend_api(struct bm_device_info *bmdi, struct file *file, unsigned char *msg)
+static int ksend_api(struct bm_device_info *bmdi, struct file *file, unsigned char *msg)
 {
 	int ret = 0;
 	struct bm_thread_info *thd_info;

--- a/driver/bm_attr.c
+++ b/driver/bm_attr.c
@@ -222,7 +222,7 @@ int bmdrv_get_tpu_target_freq(struct bm_device_info *bmdi, enum bm_freq_scaling_
 }
 #endif
 
-void bmdrv_thermal_init(struct bm_device_info *bmdi)
+static void bmdrv_thermal_init(struct bm_device_info *bmdi)
 {
 	int i = 0;
 
@@ -259,7 +259,7 @@ static void  calculate_board_status(struct bm_device_info *bmdi)
 	}
 }
 
-void board_status_update(struct bm_device_info *bmdi, int cur_tmp, int cur_tpu_clk)
+static void board_status_update(struct bm_device_info *bmdi, int cur_tmp, int cur_tpu_clk)
 {
 	int fusing_tmp = 95;
 	int support_tmp = 90;
@@ -363,7 +363,7 @@ extreme:
 }
 #endif
 
-void bmdrv_thermal_update_status(struct bm_device_info *bmdi, int cur_tmp)
+static void bmdrv_thermal_update_status(struct bm_device_info *bmdi, int cur_tmp)
 {
 	int avg_tmp = 0;
 	int cur_tpu_clk = 0;
@@ -894,7 +894,7 @@ int set_ecc(struct bm_device_info *bmdi, int ecc_enable)
 }
 
 #ifndef SOC_MODE
-int board_type_sc5_rev_to_duty(u16 fan_rev)
+static int board_type_sc5_rev_to_duty(u16 fan_rev)
 {
 	u32 fan_duty = 0;
 
@@ -919,7 +919,7 @@ int board_type_sc5_rev_to_duty(u16 fan_rev)
 	return fan_duty;
 }
 
-int board_type_sc5h_rev_to_duty(u16 fan_rev)
+static int board_type_sc5h_rev_to_duty(u16 fan_rev)
 {
 	u32 fan_duty = 0;
 
@@ -940,7 +940,7 @@ int board_type_sc5h_rev_to_duty(u16 fan_rev)
 	return fan_duty;
 }
 
-int bm_get_fixed_fan_speed(struct bm_device_info *bmdi, u32 temp)
+static int bm_get_fixed_fan_speed(struct bm_device_info *bmdi, u32 temp)
 {
 	u16 fan_spd = 100;
 
@@ -1443,38 +1443,38 @@ static int bm_read_1331_temp(struct bm_device_info *bmdi, int id, u32 *temp)
 	return ret;
 }
 
-int bm_read_sc5_pro_tpu_voltage(struct bm_device_info *bmdi, u32 *volt)
+static int bm_read_sc5_pro_tpu_voltage(struct bm_device_info *bmdi, u32 *volt)
 {
 	*volt = mcu_info_reg_read(bmdi, 0xc);
 	return 0;
 }
 
-int bm_read_sc5_pro_tpu_current(struct bm_device_info *bmdi, u32 *cur)
+static int bm_read_sc5_pro_tpu_current(struct bm_device_info *bmdi, u32 *cur)
 {
 	*cur = mcu_info_reg_read(bmdi, 0x10);
 	return 0;
 }
 
-int bm_read_sc5_pro_tpu_power(struct bm_device_info *bmdi, u32 *power)
+static int bm_read_sc5_pro_tpu_power(struct bm_device_info *bmdi, u32 *power)
 {
 	*power = mcu_info_reg_read(bmdi, 0x14);
 	*power = *power / 1000;
 	return 0;
 }
 
-int bm_read_sc7_pro_vddc_voltage(struct bm_device_info *bmdi, u32 *volt)
+static int bm_read_sc7_pro_vddc_voltage(struct bm_device_info *bmdi, u32 *volt)
 {
 	*volt = mcu_info_reg_read(bmdi, 0x18);
 	return 0;
 }
-int bm_read_sc7_pro_vddc_power(struct bm_device_info *bmdi, u32 *power)
+static int bm_read_sc7_pro_vddc_power(struct bm_device_info *bmdi, u32 *power)
 {
 	*power = mcu_info_reg_read(bmdi, 0x20);
 	*power = *power / 1000;
 	return 0;
 }
 
-int bm_read_sc7_pro_vddphy_power(struct bm_device_info *bmdi, u32 *power)
+static int bm_read_sc7_pro_vddphy_power(struct bm_device_info *bmdi, u32 *power)
 {
 	*power = mcu_info_reg_read(bmdi, 0x2c);
 	*power = *power / 1000;
@@ -1906,7 +1906,7 @@ int bm_read_mcu_voltage(struct bm_device_info *bmdi, u8 lo, u32 *volt)
 	return 0;
 }
 
-int bm_read_board_current(struct bm_device_info *bmdi, u32 *cur)
+static int bm_read_board_current(struct bm_device_info *bmdi, u32 *cur)
 {
 
 	int ret = 0;
@@ -2692,7 +2692,7 @@ int bm_get_name(struct bm_device_info *bmdi, unsigned long arg) {
 }
 
 #ifndef SOC_MODE
-int bmdrv_find_first_chip_logic_chip_id(struct bm_device_info *bmdi)
+static int bmdrv_find_first_chip_logic_chip_id(struct bm_device_info *bmdi)
 {
 	u32 chip_num = 0;
 	u32 value = 0;
@@ -3228,7 +3228,7 @@ int bmdrv_volt_freq_scaling(struct bm_device_info *bmdi)
 	return 0;
 }
 
-int bmdev_get_smi_attr(struct bm_device_info *bmdi, struct bm_smi_attr *pattr)
+static int bmdev_get_smi_attr(struct bm_device_info *bmdi, struct bm_smi_attr *pattr)
 {
 	struct chip_info *cinfo;
 	int i;

--- a/driver/bm_card.c
+++ b/driver/bm_card.c
@@ -10,7 +10,7 @@
 
 static struct bm_card *g_bmcd[BM_MAX_CARD_NUM] = {NULL};
 
-int bm_card_get_chip_num(struct bm_device_info *bmdi)
+static int bm_card_get_chip_num(struct bm_device_info *bmdi)
 {
 #ifdef SOC_MODE
 	return 1;
@@ -83,7 +83,7 @@ static int bm_update_sc5p_mcu_bmdi_to_card(struct bm_device_info *bmdi)
 #endif
 
 #ifndef SOC_MODE
-int bm_card_update_sn(struct bm_device_info *bmdi, char *sn)
+static int bm_card_update_sn(struct bm_device_info *bmdi, char *sn)
 {
 	if ((BM1684_BOARD_TYPE(bmdi) == BOARD_TYPE_SC5_PLUS) ||
 		(BM1684_BOARD_TYPE(bmdi) == BOARD_TYPE_CP24) ||

--- a/driver/bm_debug.c
+++ b/driver/bm_debug.c
@@ -2342,7 +2342,7 @@ void bmdrv_proc_file_deinit(struct bm_device_info *bmdi)
 
 #undef MAX_NAMELEN
 
-bool bm_arm9fw_log_buffer_empty(struct bm_device_info *bmdi)
+static bool bm_arm9fw_log_buffer_empty(struct bm_device_info *bmdi)
 {
 	int read_index = 0;
 	int write_index = 0;
@@ -2354,7 +2354,7 @@ bool bm_arm9fw_log_buffer_empty(struct bm_device_info *bmdi)
 
 }
 
-int bm_get_arm9fw_log_from_device(struct bm_device_info *bmdi)
+static int bm_get_arm9fw_log_from_device(struct bm_device_info *bmdi)
 {
 	int read_p = gp_reg_read_enh(bmdi, GP_REG_ARM9FW_LOG_RP);
 	int write_p = gp_reg_read_enh(bmdi, GP_REG_ARM9FW_LOG_WP);
@@ -2413,7 +2413,7 @@ int bm_get_arm9fw_log_from_device(struct bm_device_info *bmdi)
 #define ARM9FW_LOG_DEVICE_BUFFER_SIZE (1024 * 1024 * 4)
 #define ARM9FW_LOG_LINE_SIZE 512
 
-void bm_print_arm9fw_log(struct bm_device_info *bmdi, int size)
+static void bm_print_arm9fw_log(struct bm_device_info *bmdi, int size)
 {
 	char str[ARM9FW_LOG_LINE_SIZE] = "";
 	int i = 0;
@@ -2457,7 +2457,7 @@ int bm_arm9fw_log_init(struct bm_device_info *bmdi)
 }
 
 #ifndef SOC_MODE
-void bm_i2c2_reset(struct bm_device_info *bmdi)
+static void bm_i2c2_reset(struct bm_device_info *bmdi)
 {
 	u32 value = 0;
         struct bm_chip_attr *c_attr = &bmdi->c_attr;
@@ -2474,7 +2474,7 @@ void bm_i2c2_reset(struct bm_device_info *bmdi)
 	mutex_unlock(&c_attr->attr_mutex);
 }
 
-void bm_i2c2_recovey(struct bm_device_info *bmdi) {
+static void bm_i2c2_recovey(struct bm_device_info *bmdi) {
 	u32 i2c_index = 0x2;
 	u32 addr = i2c_reg_read(bmdi, i2c_index, 0x8);
 	u32 intc_mask = i2c_reg_read(bmdi, i2c_index, 0x30);
@@ -2497,7 +2497,7 @@ void bm_i2c2_recovey(struct bm_device_info *bmdi) {
 	i2c_reg_write(bmdi, i2c_index, 0x6c, 1);
 }
 
-int is_i2c2_idle(struct bm_device_info *bmdi) {
+static int is_i2c2_idle(struct bm_device_info *bmdi) {
 	int i = 0x0;
 	u32 i2c2_status = 0;
 	u32 i2c_index = 0x2;
@@ -2512,7 +2512,7 @@ int is_i2c2_idle(struct bm_device_info *bmdi) {
 	return 0;
 }
 
-int i2c2_disable(struct bm_device_info *bmdi) {
+static int i2c2_disable(struct bm_device_info *bmdi) {
 	int i2c_index = 0x2;
 	bm_i2c2_reset(bmdi);
 	i2c_reg_write(bmdi, i2c_index, 0x6c, 0);
@@ -2528,7 +2528,7 @@ int i2c2_deinit(struct bm_device_info *bmdi) {
 	return 0;
 }
 
-int bm_i2c2_need_recovery(struct bm_device_info *bmdi) {
+static int bm_i2c2_need_recovery(struct bm_device_info *bmdi) {
 	u32 i2c2_status = 0;
 	u32 i2c2_count_old = 0;
 	u32 i2c2_count_new = 0;

--- a/driver/bm_fops.c
+++ b/driver/bm_fops.c
@@ -1144,7 +1144,7 @@ static long bm_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		{
 		struct bm_chip_attr *c_attr = &bmdi->c_attr;
 		mutex_lock(&c_attr->attr_mutex);
-		if (copy_from_user(&bmdi->enable_dyn_freq, (unsigned int __user *)arg, sizeof(int)));
+		if (copy_from_user(&bmdi->enable_dyn_freq, (unsigned int __user *)arg, sizeof(int))){}
 		mutex_unlock(&c_attr->attr_mutex);
 		break;
 		}

--- a/driver/bm_genalloc.c
+++ b/driver/bm_genalloc.c
@@ -36,6 +36,7 @@
 #include <linux/of_device.h>
 #include <linux/vmalloc.h>
 #include <linux/version.h>
+#include <linux/device.h>
 #include "bm_genalloc.h"
 static inline size_t chunk_size(const struct bm_gen_pool_chunk *chunk)
 {

--- a/driver/bm_io.c
+++ b/driver/bm_io.c
@@ -201,7 +201,7 @@ u64 bm_write64(struct bm_device_info *bmdi, u32 address, u64 data)
 	return 0;
 }
 
-void bm_reg_init_vaddr(struct bm_device_info *bmdi, u32 address, void __iomem **reg_base_vaddr)
+static void bm_reg_init_vaddr(struct bm_device_info *bmdi, u32 address, void __iomem **reg_base_vaddr)
 {
 	u32 offset = 0;
 	struct bm_bar_info *pbar_info = &bmdi->cinfo.bar_info;

--- a/driver/bm_memcpy.c
+++ b/driver/bm_memcpy.c
@@ -87,7 +87,7 @@ int bmdrv_stagemem_free(struct bm_device_info *bmdi, u64 paddr, void *vaddr, u64
 	return 0;
 }
 /*bit_n == 0, slot n is free, bit_n == 1, slot n is used*/
-int caculate_stage_index(int *bitmap, int *index)
+static int caculate_stage_index(int *bitmap, int *index)
 {
 	int i = 0;
 
@@ -101,7 +101,7 @@ int caculate_stage_index(int *bitmap, int *index)
 	return -1;
 }
 
-int bmdrv_free_stagemem(struct bm_device_info *bmdi, MEMCPY_DIR dir, int index) {
+static int bmdrv_free_stagemem(struct bm_device_info *bmdi, MEMCPY_DIR dir, int index) {
 	struct bm_memcpy_info *memcpy_info = &bmdi->memcpy_info;
 
 	if (dir == HOST2CHIP) {
@@ -119,7 +119,7 @@ int bmdrv_free_stagemem(struct bm_device_info *bmdi, MEMCPY_DIR dir, int index) 
 	return 0;
 }
 
-int bmdrv_get_stagemem(struct bm_device_info *bmdi, u64 *ppaddr,
+static int bmdrv_get_stagemem(struct bm_device_info *bmdi, u64 *ppaddr,
 		void **pvaddr, MEMCPY_DIR dir, int *index)
 {
 
@@ -267,7 +267,7 @@ void bmdev_construct_cdma_arg(pbm_cdma_arg parg,
 	parg->use_iommu = use_iommu;
 }
 
-void bmdev_construct_smmu_arg(struct iommu_region *iommu_rgn,
+static void bmdev_construct_smmu_arg(struct iommu_region *iommu_rgn,
 		u64 user_start,
 		u64 user_size,
 		u32 is_dst,
@@ -502,7 +502,7 @@ int bmdev_memcpy_d2s(struct bm_device_info *bmdi, struct file *file, void __user
 	return ret;
 }
 
-int bmdev_memcpy_c2c(struct bm_device_info *bmdi, struct file *file, u64 src, u64 dst, u32 size,
+static int bmdev_memcpy_c2c(struct bm_device_info *bmdi, struct file *file, u64 src, u64 dst, u32 size,
 		bool intr, bm_cdma_iommu_mode cdma_iommu_mode)
 {
 	int ret = 0;
@@ -595,7 +595,7 @@ int bmdev_memcpy_p2p(struct bm_device_info *bmdi, struct file *file, unsigned lo
 	return ret;
 }
 
-int bmdev_memcpy_p2p_test(struct bm_device_info *bmdi_src, struct bm_device_info *bmdi_dst)
+static int bmdev_memcpy_p2p_test(struct bm_device_info *bmdi_src, struct bm_device_info *bmdi_dst)
 {
 	int size = 0x1000;
 	void *vaddr_src = NULL, *vaddr_dst = NULL;

--- a/driver/bm_monitor.c
+++ b/driver/bm_monitor.c
@@ -18,7 +18,7 @@
 
 #define SC7_PRO_HAS_VFS
 
-int bm_monitor_thread(void *date)
+static int bm_monitor_thread(void *date)
 {
 	int ret = 0;
 	struct bm_device_info *bmdi = (struct bm_device_info *)date;

--- a/driver/bm_napi.c
+++ b/driver/bm_napi.c
@@ -117,7 +117,7 @@ exit:
     return skb;
 }
 
-int bm1684_clear_ethirq(struct bm_device_info *bmdi) {
+static int bm1684_clear_ethirq(struct bm_device_info *bmdi) {
     u32 value;
 
     value = (1 << 2);
@@ -125,7 +125,7 @@ int bm1684_clear_ethirq(struct bm_device_info *bmdi) {
     return 0;
 }
 
-void bmdrv_eth_irq_handler(struct bm_device_info *bmdi) {
+static void bmdrv_eth_irq_handler(struct bm_device_info *bmdi) {
     struct eth_dev_info *eth = &bmdi->vir_eth;
 
     bm1684_clear_ethirq(bmdi);
@@ -169,7 +169,7 @@ static netdev_tx_t eth_ndo_start_xmit(struct sk_buff *   skb,
 
 #ifndef CENTOS_KERNEL_FIX
 	#if  LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
-void eth_ndo_tx_timeout(struct net_device *ndev, unsigned int txqueue)
+static void eth_ndo_tx_timeout(struct net_device *ndev, unsigned int txqueue)
 	#else
 static void eth_ndo_tx_timeout(struct net_device *ndev)
 	#endif
@@ -346,7 +346,7 @@ exit:
     return ret;
 }
 
-int napi_handle_irq(struct eth_dev_info *info) {
+static int napi_handle_irq(struct eth_dev_info *info) {
     napi_schedule(&info->napi);
     return 0;
 }

--- a/driver/bm_pcie_drv.c
+++ b/driver/bm_pcie_drv.c
@@ -60,6 +60,9 @@ typedef struct bm_api_reset_cpu {
 } __attribute__((packed)) bm_api_reset_cpu_t;
 #endif
 
+void bmdrv_modules_request_irq(struct bm_device_info *bmdi);
+int bmdrv_reset_bmcpu(struct bm_device_info *bmdi);
+
 static int bmdrv_pci_init_bar_address(struct pci_dev *pdev, struct chip_info *cinfo)
 {
 	int rc;
@@ -601,7 +604,7 @@ void bmdrv_modules_request_irq(struct bm_device_info *bmdi)
 	}
 }
 
-void bmdrv_modules_free_irq(struct bm_device_info *bmdi)
+static void bmdrv_modules_free_irq(struct bm_device_info *bmdi)
 {
 	bm_cdma_free_irq(bmdi);
 	if (bmdi->cinfo.chip_id == 0x1682)
@@ -659,7 +662,7 @@ static u32 bmdrv_get_a53_boot_args(struct bm_device_info *bmdi)
 	return flag;
 }
 
-int bmdrv_force_reset_bmcpu(struct bm_device_info *bmdi) {
+static int bmdrv_force_reset_bmcpu(struct bm_device_info *bmdi) {
 	int                  ret = 0;
 	u32                  flag  = 0xabcdabcd;
 	int                  retry = 3;
@@ -741,7 +744,7 @@ int bmdrv_force_reset_bmcpu(struct bm_device_info *bmdi) {
 	return ret;
 }
 
-int bmdrv_force_reset_bmcpu_pcie(struct bm_device_info *bmdi) {
+static int bmdrv_force_reset_bmcpu_pcie(struct bm_device_info *bmdi) {
 	int                  ret = 0;
 	u32                  flag  = 0xabcdabcd;
 	int                  retry = 3;
@@ -781,7 +784,7 @@ int bmdrv_force_reset_bmcpu_pcie(struct bm_device_info *bmdi) {
 	return ret;
 }
 
-void bmdrv_fw_unload_mix(struct bm_device_info *bmdi)
+static void bmdrv_fw_unload_mix(struct bm_device_info *bmdi)
 {
 	// u32 ctrl_word;
 	int value = 0x0;
@@ -925,7 +928,7 @@ int bmdrv_reset_bmcpu(struct bm_device_info *bmdi)
 }
 #endif
 
-void bmdrv_init_devid_array(void)
+static void bmdrv_init_devid_array(void)
 {
 	int i = 0;
 	struct bm_pcie_record *p = bm_record;
@@ -939,7 +942,7 @@ void bmdrv_init_devid_array(void)
 	}
 }
 
-int bmdrv_check_domain_bdf(int domain_bdf)
+static int bmdrv_check_domain_bdf(int domain_bdf)
 {
 	int i = 0;
 	struct bm_pcie_record *p = bm_record;
@@ -954,7 +957,7 @@ int bmdrv_check_domain_bdf(int domain_bdf)
 	return -1;
 }
 
-void bmdrv_dump_pcie_record(void)
+static void bmdrv_dump_pcie_record(void)
 {
 	int i = 0;
 	struct bm_pcie_record *p = bm_record;
@@ -967,7 +970,7 @@ void bmdrv_dump_pcie_record(void)
 	}
 }
 
-int bmdrv_alloc_dev_index(struct pci_dev *pdev)
+static int bmdrv_alloc_dev_index(struct pci_dev *pdev)
 {
 	int dev_index = 0;
 	int i = 0;

--- a/driver/bm_wdt.c
+++ b/driver/bm_wdt.c
@@ -7,6 +7,7 @@
 #include "bm_common.h"
 #include "bm_io.h"
 #include "bm1684_reg.h"
+#include "bm_wdt.h"
 
 #define WDOG_CONTROL_REG_OFFSET		    0x00
 #define WDOG_CONTROL_REG_WDT_EN_MASK	    0x01

--- a/driver/gpio.c
+++ b/driver/gpio.c
@@ -16,15 +16,16 @@
 #define GPIO_INT_STAUS		 0x040
 #define GPIO_PORTA_EOI		 0x04c
 
-void bmdrv_gpio_irq(struct bm_device_info *bmdi)
+static void bmdrv_gpio_irq(struct bm_device_info *bmdi)
 {
 	int reg_val;
 
 	reg_val = gpio_reg_read(bmdi, GPIO_INT_STAUS);
-	if (reg_val & 0x80000000)
+	if (reg_val & 0x80000000) {
 		PR_TRACE("GPIO 31 interrupt\n");
-	else
+	} else {
 		PR_TRACE("GPIO unknown interrupt\n");
+	}
 	gpio_reg_write(bmdi, GPIO_PORTA_EOI, 0xffffffff);
 }
 

--- a/driver/i2c.c
+++ b/driver/i2c.c
@@ -187,7 +187,7 @@ int bm_i2c_set_target_addr(struct bm_device_info *bmdi, u32 i2c_index, u32 targe
 	return 0;
 }
 
-void bm_i2c_recovery(struct bm_device_info *bmdi, u32 i2c_index)
+static void bm_i2c_recovery(struct bm_device_info *bmdi, u32 i2c_index)
 {
 	u32 i2c_addr = 0;
 	u32 tx_level = 0;
@@ -589,7 +589,7 @@ int bm_mcu_read_reg(struct bm_device_info *bmdi, u8 cmd, u8 *data)
 	return ret;
 }
 
-int bm_mcu_send_u32(struct bm_device_info *bmdi, u8 cmd, u32 data)
+static int bm_mcu_send_u32(struct bm_device_info *bmdi, u8 cmd, u32 data)
 {
 	u8 buf[4];
 	int ret = 0;

--- a/driver/pwm.c
+++ b/driver/pwm.c
@@ -1,4 +1,5 @@
 #include "bm_common.h"
+#include "pwm.h"
 
 /*pwm register*/
 

--- a/driver/spi.c
+++ b/driver/spi.c
@@ -353,7 +353,7 @@ static int spi_read_status(struct bm_device_info *bmdi)
 	return data_buf[0];
 }
 
-u32 bm_spi_read_id(struct bm_device_info *bmdi)
+static u32 bm_spi_read_id(struct bm_device_info *bmdi)
 {
 	u8 cmd_buf[4];
 	u8 data_buf[4];

--- a/driver/vpp/bm1684_vpp.c
+++ b/driver/vpp/bm1684_vpp.c
@@ -287,7 +287,7 @@ __maybe_unused static int vpp_cores_reset(struct bm_device_info *bmdi)
 	return 0;
 }
 
-void vpp_clear_int(struct bm_device_info *bmdi, int core_id)
+static void vpp_clear_int(struct bm_device_info *bmdi, int core_id)
 {
 	if (core_id == 0)
 		vpp0_reg_write(bmdi, VPP_INT_CLEAR, 0xffffffff);
@@ -295,7 +295,7 @@ void vpp_clear_int(struct bm_device_info *bmdi, int core_id)
 		vpp1_reg_write(bmdi, VPP_INT_CLEAR, 0xffffffff);
 }
 
-void vpp_irq_handler(struct bm_device_info *bmdi, int core_id)
+static void vpp_irq_handler(struct bm_device_info *bmdi, int core_id)
 {
 	bmdi->vppdrvctx.got_event_vpp[core_id] = 1;
 	wake_up(&bmdi->vppdrvctx.wq_vpp[core_id]);
@@ -661,7 +661,7 @@ __maybe_unused static void dump_des(struct vpp_batch *batch, struct vpp_descript
 	}
 }
 
-void vpp_dump(struct vpp_batch *batch)
+static void vpp_dump(struct vpp_batch *batch)
 {
 	struct vpp_cmd *cmd ;
 	int i;
@@ -715,7 +715,7 @@ void vpp_dump(struct vpp_batch *batch)
 	return;
 }
 
-int vpp_handle_setup(struct bm_device_info *bmdi, struct vpp_batch *batch)
+static int vpp_handle_setup(struct bm_device_info *bmdi, struct vpp_batch *batch)
 {
 	int ret = VPP_OK, ret1 = VPP_ERR, idx = 0;
 	u64 *vpp_desc_pa;

--- a/driver/vpu/vmm.h
+++ b/driver/vpu/vmm.h
@@ -24,7 +24,9 @@
 #define VMEM_ASSERT(_exp)        if (!(_exp)) { printk(KERN_INFO "VMEM_ASSERT at %s:%d\n", __FILE__, __LINE__); /*while(1);*/ }
 #define VMEM_HEIGHT(_tree)       (_tree == NULL ? -1 : _tree->height)
 
+#ifndef MAX
 #define MAX(_a, _b)         (_a >= _b ? _a : _b)
+#endif
 
 typedef enum {
     LEFT,

--- a/driver/vpu/vpu.c
+++ b/driver/vpu/vpu.c
@@ -437,7 +437,7 @@ static void release_vpu_create_inst_flag(struct bm_device_info *bmdi, int core_i
 }
 
 #ifdef VPU_SUPPORT_CLOSE_COMMAND
-int CodaCloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
+static int CodaCloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
 {
 	int ret = 0;
 	unsigned long timeout = jiffies + HZ; /* vpu wait timeout to 1sec */
@@ -599,7 +599,7 @@ static int FlushEncResult(struct bm_device_info *bmdi, u32 core, u32 instanceInd
     return 0;
 }
 
-int Wave5CloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
+static int Wave5CloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
 {
 	int ret = 0;
 	int regVal;
@@ -640,7 +640,7 @@ DONE_CMD:
 	return ret;
 }
 
-int CloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
+static int CloseInstanceCommand(struct bm_device_info *bmdi, int core, u32 instanceIndex)
 {
 	int product_code;
 	int ret = 0;
@@ -1243,16 +1243,17 @@ static int polling_interrupt_work(void *data)
 	return 0;
 }
 
-void create_irq_poll_thread(void)
+static void create_irq_poll_thread(void)
 {
 	irq_task = kthread_run(polling_interrupt_work, NULL, "IrqPoll");
-	if (IS_ERR(irq_task))
+	if (IS_ERR(irq_task)) {
 		DPRINTK(KERN_ERR "[VPUDRV] : %s failed!\n", __func__);
-	else
+	} else {
 		DPRINTK("[VPUDRV] : %s sucess!\n", __func__);
+	}
 }
 
-void destory_irq_poll_thread(void)
+static void destory_irq_poll_thread(void)
 {
 	if (irq_task) {
 		kthread_stop(irq_task);
@@ -2708,23 +2709,25 @@ static int bm_vpu_reset_core(struct bm_device_info *bmdi, int core_idx, int rese
 
     if (bmdi->cinfo.chip_id == 0x1684) {
 		value = bm_read32(bmdi, bm_vpu_rst[core_idx].reg);
-		if (reset == 0)
+		if (reset == 0) {
 			value &= ~(0x1 << bm_vpu_rst[core_idx].bit_n);
-		else if (reset == 1)
+		} else if (reset == 1) {
 			value |= (0x1 << bm_vpu_rst[core_idx].bit_n);
-		else
+		} else {
 			DPRINTK(KERN_ERR "VPUDRV :vpu reset unsupported operation\n");
+		}
 		bm_write32(bmdi, bm_vpu_rst[core_idx].reg, value);
 		value = bm_read32(bmdi, bm_vpu_rst[core_idx].reg);
 	}
     if (bmdi->cinfo.chip_id == 0x1686) {
 		value = bm_read32(bmdi, bm_vpu_rst_1686[core_idx].reg);
-		if (reset == 0)
+		if (reset == 0) {
 			value &= ~(0x1 << bm_vpu_rst_1686[core_idx].bit_n);
-		else if (reset == 1)
+		} else if (reset == 1) {
 			value |= (0x1 << bm_vpu_rst_1686[core_idx].bit_n);
-		else
+		} else {
 			DPRINTK(KERN_ERR "VPUDRV :vpu reset unsupported operation\n");
+		}
 		bm_write32(bmdi, bm_vpu_rst_1686[core_idx].reg, value);
 		value = bm_read32(bmdi, bm_vpu_rst_1686[core_idx].reg);
 	}

--- a/driver/xmodem.c
+++ b/driver/xmodem.c
@@ -1,5 +1,6 @@
 #include "uart.h"
 #include "bm_timer.h"
+#include "xmodem.h"
 
 #define TIMEOUT          (200)
 


### PR DESCRIPTION
Archlinux dkms build failed for "no previous prototype"

solutions:
1. add prototype if it's an exported function and no standalone header file.
2. include the missing headers
3. add static if it is used internally.